### PR TITLE
Update server setup script and documentation

### DIFF
--- a/PowerShell/Exfiltration/HTTP/Setup-LocalWebServer.md
+++ b/PowerShell/Exfiltration/HTTP/Setup-LocalWebServer.md
@@ -52,6 +52,7 @@
 3. **Start Server:** Runs Python HTTP server in background.
 4. **Browser Launch:** Opens site unless `-NoBrowser` specified.
 5. **Stop Operation:** Kills server and restores hosts file when `-StopServer` used.
+6. **Cleanup:** Removes temporary files after stopping the server.
 
 ## Output
 - Website available at `http://yourdomain.tld:port/`

--- a/PowerShell/Exfiltration/HTTP/Setup-LocalWebServer.md
+++ b/PowerShell/Exfiltration/HTTP/Setup-LocalWebServer.md
@@ -30,7 +30,6 @@
 | StopServer     | switch | No        | Stops server, restores hosts file, and exits               |
 
 ## Usage
-
 ### Start the Web Server
 ```powershell
 .\Setup-LocalWebServer.ps1 -Domain "mytestsite" -TLD "local"


### PR DESCRIPTION
- Added cleanup step in documentation for temporary files.
- Changed default template folder from "template" to "html".
- Updated template download URL to a raw link for accuracy.
- Enhanced `Download-Template` function with error handling.
- Added checks to ensure successful creation of the template folder.
- Included validation in `Start-PythonServer` for template folder existence.
- Add removing temp folder after stopping the server in `Stop-PythonServer` .
- Implemented TLD formatting check to ensure correct server address.
- Clarified output messages regarding web folder usage and stopping the server.