### PR TITLE
Add Restart-ServiceOnCrash script and documentation

### DIFF
--- a/PowerShell/DefenseEvasion/ProcessManipulation/Restart-ServiceOnCrash.md
+++ b/PowerShell/DefenseEvasion/ProcessManipulation/Restart-ServiceOnCrash.md
@@ -1,0 +1,76 @@
+# Restart-ServiceOnCrash.ps1
+
+## Overview
+**Restart-ServiceOnCrash.ps1** is a PowerShell script for Windows 10/11/Server that continuously monitors a specified critical service. If the service stops or crashes, the script attempts to restart it up to a configurable maximum number of times, logging every attempt and optionally exporting logs in CSV or JSON format. It is ideal for ensuring uptime of important services.
+
+## Features
+- **Service Monitoring:** Watches a specified service and detects when it is stopped or not found.
+- **Automatic Recovery:** Attempts to restart the service up to a configurable number of times (`MaxAttempts`).
+- **Logging:** Logs each stop and restart attempt with timestamps, status, and result.
+- **Export:** Optionally exports log data to CSV and/or JSON.
+- **Configurable:** Choose monitoring interval, max restart attempts, and log export formats.
+- **User Feedback:** Color-coded, clear messages and summary at session end.
+
+## Parameters
+| Name           | Type    | Required | Default                                             | Description                           |
+|----------------|---------|----------|-----------------------------------------------------|---------------------------------------|
+| Service        | string  | Yes      | -                                                   | Service name to monitor (short name)  |
+| IntervalSeconds| int     | No       | 30                                                  | Monitoring interval (seconds)         |
+| MaxAttempts    | int     | No       | 3                                                   | Maximum restart attempts per failure  |
+| ExportLogCsv   | switch  | No       | Off                                                 | Export log as CSV                     |
+| CsvPath        | string  | No       | ServiceRestartLog_${Service}_<timestamp>.csv        | Path for CSV export                   |
+| ExportLogJson  | switch  | No       | Off                                                 | Export log as JSON                    |
+| JsonPath       | string  | No       | ServiceRestartLog_${Service}_<timestamp>.json       | Path for JSON export                  |
+
+## Usage
+**Monitor and auto-restart a service:**
+```powershell
+.\Restart-ServiceOnCrash.ps1 -Service "Spooler"
+```
+
+**Export logs to CSV and JSON:**
+```powershell
+.\Restart-ServiceOnCrash.ps1 -Service "wuauserv" -ExportLogCsv -ExportLogJson
+```
+
+**Set custom interval and max attempts:**
+```powershell
+.\Restart-ServiceOnCrash.ps1 -Service "WinRM" -IntervalSeconds 60 -MaxAttempts 5
+```
+
+## Output Example
+```
+Surveillance du service critique : Spooler
+==========================================
+Démarrage de la surveillance. (Ctrl+C pour arrêter)
+2025-07-29 19:27:34 | Attention : Le service 'Spooler' n'est pas démarré (état = Stopped).
+2025-07-29 19:27:34 | Redémarrage du service 'Spooler' réussi (tentative 1).
+Résumé : Service stoppé 2 fois, redémarré 2 fois.
+[FIN] Surveillance terminée.
+```
+
+## Help & Documentation
+```powershell
+Get-Help .\Restart-ServiceOnCrash.ps1
+man .\Restart-ServiceOnCrash.ps1
+```
+
+## Troubleshooting
+
+- **Correct Service Name:** Use the short name as shown in `services.msc` (e.g., `Spooler` for the Print Spooler).
+- **Permissions:** Some services require Administrator rights to restart.
+- **Export Paths:** By default, logs are saved in the script directory with timestamps.
+- **Session End:** Logs are exported when script exits (e.g., Ctrl+C).
+
+## License
+```
+MIT License
+
+Copyright (c) 2025 Miiraak
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```

--- a/PowerShell/DefenseEvasion/ProcessManipulation/Restart-ServiceOnCrash.ps1
+++ b/PowerShell/DefenseEvasion/ProcessManipulation/Restart-ServiceOnCrash.ps1
@@ -1,0 +1,170 @@
+########################################################################################################
+#                                                                                                      #
+#                   ███▄ ▄███▓ ██▓ ██▓ ██▀███   ▄▄▄      ▄▄▄       ██ ▄█▀                              #
+#                  ▓██▒▀█▀ ██▒▓██▒▓██▒▓██ ▒ ██▒▒████▄   ▒████▄     ██▄█▒                               #
+#                  ▓██    ▓██░▒██▒▒██▒▓██ ░▄█ ▒▒██  ▀█▄ ▒██  ▀█▄  ▓███▄░                               #
+#                  ▒██    ▒██ ░██░░██░▒██▀▀█▄  ░██▄▄▄▄██░██▄▄▄▄██ ▓██ █▄                               #
+#                  ▒██▒   ░██▒░██░░██░░██▓ ▒██▒ ▓█   ▓██▒▓█   ▓██▒▒██▒ █▄                              #
+#                  ░ ▒░   ░  ░░▓  ░▓  ░ ▒▓ ░▒▓░ ▒▒   ▓▒█░▒▒   ▓▒█░▒ ▒▒ ▓▒                              #
+#                  ░  ░      ░ ▒ ░ ▒ ░  ░▒ ░ ▒░  ▒   ▒▒ ░ ▒   ▒▒ ░░ ░▒ ▒░                              #
+#                  ░      ░    ▒ ░ ▒ ░  ░░   ░   ░   ▒    ░   ▒   ░ ░░ ░                               #
+#                         ░    ░   ░     ░           ░  ░     ░  ░░  ░                                 #
+#                                                                                                      #
+#     Title        : Restart-ServiceOnCrash.ps1                                                        #
+#     Link         : https://github.com/Miiraak/Scripts/tree/master/PowerShell/DefenseEvasion/ProcessManipulation/ #
+#     Version      : 3.2                                                                               #
+#     Category     : defenseevasion/processmanipulation                                                #
+#     Target       : Windows 10/11/Server                                                              #
+#     Description  : Monitors a critical service, restarts + logs on failure.                          #
+#                                                                                                      #
+########################################################################################################
+
+<#
+.SYNOPSIS
+    Monitors a critical service and automatically restarts it on crash/failure, with logging.
+
+.DESCRIPTION
+    Continuously monitors a specified Windows service. If the service is stopped or not found, attempts to restart it up to MaxAttempts. Logs each stop and restart attempt, with optional CSV/JSON export.
+
+.PARAMETER Service
+    Service name (short name from services.msc) to monitor.
+
+.PARAMETER IntervalSeconds
+    Monitoring interval (seconds). Default: 30.
+
+.PARAMETER MaxAttempts
+    Maximum restart attempts per incident. Default: 3.
+
+.PARAMETER ExportLogCsv
+    Export restart log as CSV.
+
+.PARAMETER CsvPath
+    Path for CSV export. Default: ServiceRestartLog_${Service}_<timestamp>.csv
+
+.PARAMETER ExportLogJson
+    Export restart log as JSON.
+
+.PARAMETER JsonPath
+    Path for JSON export. Default: ServiceRestartLog_${Service}_<timestamp>.json
+
+.EXAMPLE
+    .\Restart-ServiceOnCrash.ps1 -Service "Spooler"
+    .\Restart-ServiceOnCrash.ps1 -Service "wuauserv" -ExportLogCsv -ExportLogJson
+    .\Restart-ServiceOnCrash.ps1 -Service "WinRM" -IntervalSeconds 60 -MaxAttempts 5
+#>
+
+# -------------- [Parameters] -------------- #
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$Service,
+
+    [int]$IntervalSeconds = 30,
+    [int]$MaxAttempts = 3,
+
+    [switch]$ExportLogCsv,
+    [string]$CsvPath = "$PSScriptRoot\ServiceRestartLog_${Service}_$((Get-Date).ToString('yyyyMMdd_HHmmss')).csv",
+
+    [switch]$ExportLogJson,
+    [string]$JsonPath = "$PSScriptRoot\ServiceRestartLog_${Service}_$((Get-Date).ToString('yyyyMMdd_HHmmss')).json"
+)
+
+# -------------- [Functions] -------------- #
+function Write-Section {
+    param([string]$Title)
+    Write-Host "`n$Title" -ForegroundColor Cyan
+    Write-Host ('=' * $Title.Length) -ForegroundColor Cyan
+}
+
+# -------------- [Variables] -------------- #
+Write-Section "Monitoring critical service : $Service"
+$restartLog = @()
+$stopCount = 0
+$restartCount = 0
+
+# -------------- [Execution] -------------- #
+try {
+    Get-Service -Name $Service -ErrorAction Stop | Out-Null
+} catch {
+    Write-Host "Service '$Service' not found. Check the short name in 'services.msc'." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "Monitoring started. (Ctrl+C to stop)" -ForegroundColor Green
+
+try {
+    while ($true) {
+        try {
+            $svc = Get-Service -Name $Service -ErrorAction Stop
+            $currentStatus = $svc.Status
+        } catch {
+            $timeStamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+            Write-Host "$timeStamp | Service '$Service' not found or removed!" -ForegroundColor Red
+            $restartLog += [PSCustomObject]@{
+                DateTime = $timeStamp
+                Service  = $Service
+                Status   = "Not Found"
+                Attempt  = 0
+                Result   = "Service Not Found"
+            }
+            break
+        }
+
+        if ($currentStatus -ne 'Running') {
+            $stopCount++
+            $timeStamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+            Write-Host "$timeStamp | Warning: Service '$Service' is not running (status = $currentStatus)." -ForegroundColor Yellow
+
+            $success = $false
+            for ($i = 1; $i -le $MaxAttempts; $i++) {
+                try {
+                    Restart-Service -Name $Service -ErrorAction Stop
+                    $restartCount++
+                    $success = $true
+                    Write-Host "$timeStamp | Service '$Service' restarted successfully (attempt $i)." -ForegroundColor Green
+                    $restartLog += [PSCustomObject]@{
+                        DateTime = $timeStamp
+                        Service  = $Service
+                        Status   = $currentStatus
+                        Attempt  = $i
+                        Result   = "Restarted"
+                    }
+                    break
+                } catch {
+                    Write-Host "$timeStamp | Error attempt $i : $($_.Exception.Message)" -ForegroundColor Red
+                    $restartLog += [PSCustomObject]@{
+                        DateTime = $timeStamp
+                        Service  = $Service
+                        Status   = $currentStatus
+                        Attempt  = $i
+                        Result   = "Failed: $($_.Exception.Message)"
+                    }
+                    Start-Sleep -Seconds 3
+                }
+            }
+
+            if (-not $success) {
+                Write-Host "$timeStamp | Failed to restart after $MaxAttempts attempts." -ForegroundColor Red
+            }
+        }
+
+        Start-Sleep -Seconds $IntervalSeconds
+    }
+}
+finally {
+    # Export log if requested
+    if ($ExportLogCsv -and $restartLog.Count -gt 0) {
+        $restartLog | Export-Csv -Path $CsvPath -NoTypeInformation -Encoding UTF8
+        Write-Host "Log exported as CSV: $CsvPath" -ForegroundColor Cyan
+    }
+
+    if ($ExportLogJson -and $restartLog.Count -gt 0) {
+        $restartLog | ConvertTo-Json -Depth 3 | Set-Content -Path $JsonPath -Encoding UTF8
+        Write-Host "Log exported as JSON: $JsonPath" -ForegroundColor Cyan
+    }
+
+    Write-Host ""
+    Write-Host "Summary: Service stopped $stopCount times, restarted $restartCount times." -ForegroundColor Magenta
+    Write-Host "[END] Monitoring finished." -ForegroundColor White -BackgroundColor DarkGreen
+    exit 0
+}

--- a/PowerShell/DefenseEvasion/ProcessManipulation/Restart-ServiceOnCrash.ps1
+++ b/PowerShell/DefenseEvasion/ProcessManipulation/Restart-ServiceOnCrash.ps1
@@ -1,4 +1,4 @@
-########################################################################################################
+﻿########################################################################################################
 #                                                                                                      #
 #                   ███▄ ▄███▓ ██▓ ██▓ ██▀███   ▄▄▄      ▄▄▄       ██ ▄█▀                              #
 #                  ▓██▒▀█▀ ██▒▓██▒▓██▒▓██ ▒ ██▒▒████▄   ▒████▄     ██▄█▒                               #
@@ -72,8 +72,8 @@ param (
 # -------------- [Functions] -------------- #
 function Write-Section {
     param([string]$Title)
-    Write-Host "`n$Title" -ForegroundColor Cyan
-    Write-Host ('=' * $Title.Length) -ForegroundColor Cyan
+    Write-Output "`n$Title" -ForegroundColor Cyan
+    Write-Output ('=' * $Title.Length) -ForegroundColor Cyan
 }
 
 # -------------- [Variables] -------------- #
@@ -86,11 +86,11 @@ $restartCount = 0
 try {
     Get-Service -Name $Service -ErrorAction Stop | Out-Null
 } catch {
-    Write-Host "Service '$Service' not found. Check the short name in 'services.msc'." -ForegroundColor Red
+    Write-Output "Service '$Service' not found. Check the short name in 'services.msc'." -ForegroundColor Red
     exit 1
 }
 
-Write-Host "Monitoring started. (Ctrl+C to stop)" -ForegroundColor Green
+Write-Output "Monitoring started. (Ctrl+C to stop)" -ForegroundColor Green
 
 try {
     while ($true) {
@@ -99,7 +99,7 @@ try {
             $currentStatus = $svc.Status
         } catch {
             $timeStamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-            Write-Host "$timeStamp | Service '$Service' not found or removed!" -ForegroundColor Red
+            Write-Output "$timeStamp | Service '$Service' not found or removed!" -ForegroundColor Red
             $restartLog += [PSCustomObject]@{
                 DateTime = $timeStamp
                 Service  = $Service
@@ -113,7 +113,7 @@ try {
         if ($currentStatus -ne 'Running') {
             $stopCount++
             $timeStamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-            Write-Host "$timeStamp | Warning: Service '$Service' is not running (status = $currentStatus)." -ForegroundColor Yellow
+            Write-Output "$timeStamp | Warning: Service '$Service' is not running (status = $currentStatus)." -ForegroundColor Yellow
 
             $success = $false
             for ($i = 1; $i -le $MaxAttempts; $i++) {
@@ -121,7 +121,7 @@ try {
                     Restart-Service -Name $Service -ErrorAction Stop
                     $restartCount++
                     $success = $true
-                    Write-Host "$timeStamp | Service '$Service' restarted successfully (attempt $i)." -ForegroundColor Green
+                    Write-Output "$timeStamp | Service '$Service' restarted successfully (attempt $i)." -ForegroundColor Green
                     $restartLog += [PSCustomObject]@{
                         DateTime = $timeStamp
                         Service  = $Service
@@ -131,7 +131,7 @@ try {
                     }
                     break
                 } catch {
-                    Write-Host "$timeStamp | Error attempt $i : $($_.Exception.Message)" -ForegroundColor Red
+                    Write-Output "$timeStamp | Error attempt $i : $($_.Exception.Message)" -ForegroundColor Red
                     $restartLog += [PSCustomObject]@{
                         DateTime = $timeStamp
                         Service  = $Service
@@ -144,7 +144,7 @@ try {
             }
 
             if (-not $success) {
-                Write-Host "$timeStamp | Failed to restart after $MaxAttempts attempts." -ForegroundColor Red
+                Write-Output "$timeStamp | Failed to restart after $MaxAttempts attempts." -ForegroundColor Red
             }
         }
 
@@ -155,16 +155,16 @@ finally {
     # Export log if requested
     if ($ExportLogCsv -and $restartLog.Count -gt 0) {
         $restartLog | Export-Csv -Path $CsvPath -NoTypeInformation -Encoding UTF8
-        Write-Host "Log exported as CSV: $CsvPath" -ForegroundColor Cyan
+        Write-Output "Log exported as CSV: $CsvPath" -ForegroundColor Cyan
     }
 
     if ($ExportLogJson -and $restartLog.Count -gt 0) {
         $restartLog | ConvertTo-Json -Depth 3 | Set-Content -Path $JsonPath -Encoding UTF8
-        Write-Host "Log exported as JSON: $JsonPath" -ForegroundColor Cyan
+        Write-Output "Log exported as JSON: $JsonPath" -ForegroundColor Cyan
     }
 
-    Write-Host ""
-    Write-Host "Summary: Service stopped $stopCount times, restarted $restartCount times." -ForegroundColor Magenta
-    Write-Host "[END] Monitoring finished." -ForegroundColor White -BackgroundColor DarkGreen
+    Write-Output ""
+    Write-Output "Summary: Service stopped $stopCount times, restarted $restartCount times." -ForegroundColor Magenta
+    Write-Output "[END] Monitoring finished." -ForegroundColor White -BackgroundColor DarkGreen
     exit 0
 }


### PR DESCRIPTION
Introduces `Restart-ServiceOnCrash.ps1`, a PowerShell script that monitors a critical Windows service, automatically restarts it on failure, and logs the attempts. Comprehensive documentation in `Restart-ServiceOnCrash.md` details features, parameters, usage examples, and export options for logs in CSV and JSON formats. The script enhances user feedback with color-coded messages during execution.